### PR TITLE
Correct error on create: return nil for empty data sources

### DIFF
--- a/rollbar/data_source_project.go
+++ b/rollbar/data_source_project.go
@@ -40,7 +40,7 @@ func dataSourceProjectRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	if project == nil {
 		d.SetId("")
-		return fmt.Errorf("could not find project by name %s", project.Name)
+		return nil
 	}
 
 	id := fmt.Sprintf("%d", project.ID)

--- a/rollbar/data_source_project_access_key.go
+++ b/rollbar/data_source_project_access_key.go
@@ -49,7 +49,7 @@ func dataSourceProjectAccessTokenRead(d *schema.ResourceData, meta interface{}) 
 	}
 	if accessToken == nil {
 		d.SetId("")
-		return fmt.Errorf("could not find project access token by project ID %d name %s", projectID, name)
+		return nil
 	}
 
 	id := fmt.Sprintf("%d-%s", accessToken.ProjectID, accessToken.Name)


### PR DESCRIPTION
Resources should return nil instead of a cryptic error message in the CRUD hooks after `d.SetId("")` so that Terrraform can fail sensibly instead of panicking.

E.g. for undefined Rollbar projects, the error message should look like:

```
Error: Error applying plan:

1 error(s) occurred:

* output.rollbar-project-name: not found for variable 'data.rollbar_project.my-project.id'
```

instead of the somewhat dramatic:

```
!!!!!!!!!!!!!!!!!!!!!!!!!!! TERRAFORM CRASH !!!!!!!!!!!!!!!!!!!!!!!!!!!!

Terraform crashed! This is always indicative of a bug within Terraform.
A crash log has been placed at "crash.log" relative to your current
working directory. It would be immensely helpful if you could please
report the crash with Terraform[1] so that we can fix this.

When reporting bugs, please include your terraform version. That
information is available on the first line of crash.log. You can also
get it by running 'terraform --version' on the command line.

[1]: https://github.com/hashicorp/terraform/issues
```
